### PR TITLE
Feat: added missing ox_inventory exports

### DIFF
--- a/library/ox_inventory/client.lua
+++ b/library/ox_inventory/client.lua
@@ -147,6 +147,15 @@ function exports.ox_inventory:displayMetadata(metadata) end
 function exports.ox_inventory:displayMetadata(metadata, value) end
 
 ---**`client`**
+---@param func? fun(servId): string
+function exports.ox_inventory:setGetPlayerNameMethod(func) end
+
+---**`client`**
+---@param itemName string
+---@param properties ItemContainerProperties
+function exports.ox_inventory:setContainerProperties(itemName, properties) end
+
+---**`client`**
 ---@return table<string, OxClientItem> items
 function exports.ox_inventory:Items() end
 

--- a/library/ox_inventory/shared.lua
+++ b/library/ox_inventory/shared.lua
@@ -97,3 +97,9 @@ exports.ox_inventory = {}
 ---@field component? true
 ---@field throwable? boolean
 ---@field model? string
+
+---@class ItemContainerProperties
+---@field slots number
+---@field maxWeight number
+---@field whitelist? table<string, true> | string[]
+---@field blacklist? table<string, true> | string[]


### PR DESCRIPTION
Added the following exports to the types file:
* setGetPlayerNameMethod - https://github.com/overextended/ox_inventory/commit/d4d670bcfb6ea3f171828a4ecd53fcbefc972b5b
* setContainerProperties - https://github.com/overextended/ox_inventory/commit/c40ee13ab7ba4949824edbedbd00662b574681d3

Along with the `ItemContainerProperties` type to the shared file.