### PR TITLE
Tweak: registerHook parameters

### DIFF
--- a/library/ox_inventory/server.lua
+++ b/library/ox_inventory/server.lua
@@ -63,7 +63,7 @@ function exports.ox_inventory:ConvertItems(playerId, items) end
 
 ---**`server`**
 ---@param event string
----@param cb function
+---@param cb? function
 ---@param options? table
 ---@return number
 function exports.ox_inventory:registerHook(event, cb, options) end


### PR DESCRIPTION
Inline with the changes made to hooks in ox inventory, this reflects it by declaring that the callback parameter of registerHook is optional.